### PR TITLE
add extension and library version

### DIFF
--- a/rnp.c
+++ b/rnp.c
@@ -2190,6 +2190,8 @@ PHP_MINFO_FUNCTION(rnp)
 {
 	php_info_print_table_start();
 	php_info_print_table_header(2, "rnp support", "enabled");
+	php_info_print_table_row(2, "rnp extension version", PHP_RNP_VERSION);
+	php_info_print_table_row(2, "rnp library version", rnp_version_string());
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Useful for support

```
$ php --ri rnp

rnp

rnp support => enabled
rnp extension version => 0.1.1
rnp library version => 0.16.2

```