### PR TITLE
skip test using unavailable algo with OpenSSL

### DIFF
--- a/tests/010.phpt
+++ b/tests/010.phpt
@@ -2,6 +2,10 @@
 encrypt/decrypt test
 --EXTENSIONS--
 rnp
+--SKIPIF--
+<?php
+if (!strcasecmp(rnp_backend_string(), "openssl")) die("skip OpenSSL backend");
+?>
 --CAPTURE_STDIO--
 STDIN STDOUT
 --FILE--


### PR DESCRIPTION
Ignore it using OpenSSL Backend.

For memory
```

Ribose Inc. <rnpgp@ribose.com>
Backend: Botan
Backend version: 2.18.2
Supported algorithms:
Public key:  RSA, ELGAMAL, DSA, ECDH, ECDSA, EDDSA, SM2
Encryption:  IDEA, TRIPLEDES, CAST5, BLOWFISH, AES128, AES192, AES256, TWOFISH, CAMELLIA128, CAMELLIA192, CAMELLIA256, SM4
AEAD:  None, EAX, OCB
Key protection:  CFB
Hash:  MD5, SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224, SHA3-256, SHA3-512, SM3
Compression:  Uncompressed, ZIP, ZLIB, BZip2
Curves:  NIST P-256, NIST P-384, NIST P-521, Ed25519, Curve25519, brainpoolP256r1, brainpoolP384r1, brainpoolP512r1, secp256k1, SM2 P-256
Please report security issues at (https://www.rnpgp.org/feedback) and
general bugs at https://github.com/rnpgp/rnp/issues.


rnp 0.16.2
Ribose Inc. <rnpgp@ribose.com>
Backend: OpenSSL
Backend version: 1.1.1q
Supported algorithms:
Public key:  RSA, ELGAMAL, DSA, ECDH, ECDSA, EDDSA
Encryption:  IDEA, TRIPLEDES, CAST5, BLOWFISH, AES128, AES192, AES256, CAMELLIA128, CAMELLIA192, CAMELLIA256
AEAD:  None
Key protection:  CFB
Hash:  MD5, SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224, SHA3-256, SHA3-512
Compression:  Uncompressed, ZIP, ZLIB, BZip2
Curves:  NIST P-256, NIST P-384, NIST P-521, Ed25519, Curve25519, secp256k1
Please report security issues at (https://www.rnpgp.org/feedback) and
general bugs at https://github.com/rnpgp/rnp/issues.

```